### PR TITLE
Networking Improvements

### DIFF
--- a/.ansible/deploy.yaml
+++ b/.ansible/deploy.yaml
@@ -15,12 +15,12 @@
     - name: allow ports through firewall on host
       ufw:
         rule: allow
-        port: "{{ port['host'] }}"
-        proto: "{{ port['proto'] }}"
+        port: "{{ item['port'] }}"
+        proto: "{{ item['proto'] }}"
       become: yes
       loop: "{{ plex_ports }}"
       loop_control:
-        loop_var: port
+        loop_var: item
 
     - name: reload firewall and enable at boot
       ufw:

--- a/.ansible/group_vars/all/plex.yaml
+++ b/.ansible/group_vars/all/plex.yaml
@@ -3,34 +3,24 @@ plex_web_port: 32400
 
 plex_ports:
   - host: "{{ plex_web_port }}"
-    docker: 32400
     proto: tcp
   - host: 1900
-    docker: 1900
     proto: udp
   - host: 3005
-    docker: 3005
     proto: tcp
   - host: 5353
-    docker: 5353
     proto: udp
   - host: 8324
-    docker: 8324
     proto: tcp
   - host: 32410
-    docker: 32410
     proto: udp
   - host: 32412
-    docker: 32412
     proto: udp
   - host: 32413
-    docker: 32413
     proto: udp
   - host: 32414
-    docker: 32414
     proto: udp
   - host: 32469
-    docker: 32469
     proto: tcp
 
 plex_user_id: "{{ ansible_user_uid }}"

--- a/.ansible/group_vars/all/plex.yaml
+++ b/.ansible/group_vars/all/plex.yaml
@@ -2,25 +2,25 @@
 plex_web_port: 32400
 
 plex_ports:
-  - host: "{{ plex_web_port }}"
+  - port: "{{ plex_web_port }}"
     proto: tcp
-  - host: 1900
+  - port: 1900
     proto: udp
-  - host: 3005
+  - port: 3005
     proto: tcp
-  - host: 5353
+  - port: 5353
     proto: udp
-  - host: 8324
+  - port: 8324
     proto: tcp
-  - host: 32410
+  - port: 32410
     proto: udp
-  - host: 32412
+  - port: 32412
     proto: udp
-  - host: 32413
+  - port: 32413
     proto: udp
-  - host: 32414
+  - port: 32414
     proto: udp
-  - host: 32469
+  - port: 32469
     proto: tcp
 
 plex_user_id: "{{ ansible_user_uid }}"

--- a/.ansible/inventories/production/hosts
+++ b/.ansible/inventories/production/hosts
@@ -3,7 +3,7 @@ all:
 
     plex:
       hosts:
-        gpu.diesel.net:
+        quadro.diesel.net:
 
   vars:
     ansible_user: automation

--- a/.ansible/templates/docker-compose.yaml.j2
+++ b/.ansible/templates/docker-compose.yaml.j2
@@ -20,6 +20,8 @@ services:
       - {{ config_dir }}:/config
       - {{ data_dir }}:/transcode
       - nas-media:/data:ro
+    networks:
+      hostnet: {}
 
 volumes:
   nas-media:
@@ -30,3 +32,8 @@ volumes:
       type: nfs
       o: addr={{ nfs_host }},ro,nfsvers=4,async
       device: :{{ nfs_path }}
+
+networks:
+  hostnet:
+    external: true
+    name: host

--- a/.ansible/templates/docker-compose.yaml.j2
+++ b/.ansible/templates/docker-compose.yaml.j2
@@ -4,10 +4,6 @@ services:
   media-server:
     image: plexinc/pms-docker:public
     hostname: {{ plex_host }}
-    ports:
-{% for port in plex_ports %}
-      - {{ port['host'] }}:{{ port['docker'] }}/{{ port['proto'] }}
-{% endfor %}
     environment:
       - PLEX_UID={{ plex_user_id }}
       - PLEX_GID={{ plex_group_id }}

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -22,6 +22,6 @@ trigger:
   event:
     - push
   branch:
-    - stable
+    - development
 
 ...

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -22,6 +22,6 @@ trigger:
   event:
     - push
   branch:
-    - development
+    - stable
 
 ...


### PR DESCRIPTION
There was an issue where Ingress clients would get assigned IP's in the range 10.0.0.0/24 because I was using docker's Bridged networking which is essentially another NAT layer.

Switched the configuration to Host networking mode so it behaves better with local clients on my LAN